### PR TITLE
fix: cicd branches

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,9 +5,9 @@ name: Go
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "*" ]
 
 jobs:
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
         go-version: '1.22'
 
     - name: Build
-      run: make build
+      run: make build v=1
 
     - name: Test
       run: make test

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ all:
 	@$(GO) run cmd/cli/main.go
 
 .phony: build
+ifeq ($(v),1)
+BUILD_FLAGS = -v
+endif
 build:
 	@$(GO) build -o build/program/app cmd/cli/main.go
 


### PR DESCRIPTION
ci/cd now works on all branches
ci/cd uses verbose building